### PR TITLE
add test case for CypherNode

### DIFF
--- a/types/node_test.go
+++ b/types/node_test.go
@@ -30,3 +30,26 @@ func (s *TypesSuite) TestQueryNode(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(labels, DeepEquals, []string{"Test"})
 }
+
+func (s *TypesSuite) TestQueryNodeWithStringPropertiesOnly(c *C) {
+	testURL := "http://neo4j:test@localhost:7474/"
+	conn, err := sql.Open("neo4j-cypher", testURL)
+	c.Assert(err, IsNil)
+	stmt, err := conn.Prepare(`create (a:Test {foo:"bar", bar: "foo"}) return a`)
+	c.Assert(err, IsNil)
+	rows, err := stmt.Query()
+	c.Assert(err, IsNil)
+
+	rows.Next()
+	var test types.Node
+	err = rows.Scan(&test)
+	c.Assert(err, IsNil)
+	t1 := types.Node{}
+	t1.Properties = map[string]types.CypherValue{}
+	t1.Properties["foo"] = types.CypherValue{types.CypherString, "bar"}
+	t1.Properties["bar"] = types.CypherValue{types.CypherString, "foo"}
+	c.Assert(test.Properties, DeepEquals, t1.Properties)
+	labels, err := test.Labels(testURL)
+	c.Assert(err, IsNil)
+	c.Assert(labels, DeepEquals, []string{"Test"})
+}


### PR DESCRIPTION
When I tried to request one Node with only string properties a panic occured.
When I set a property with a boolean or an integer value on the same Node everything works fine again.

I'm testing against Neo4j 2.1.6 Community Edition

```
hdorio@pc$ cd types
hdorio@pc$ go test
neo4j:neo4j

----------------------------------------------------------------------
PANIC: node_test.go:34: TypesSuite.TestQueryNodeWithStringPropertiesOnly

... Panic: interface conversion: interface is map[string]string, not map[string]types.CypherValue (PC=0x426D85)

/usr/local/go/src/runtime/panic.go:387
  in gopanic
/usr/local/go/src/runtime/iface.go:225
  in assertE2T
node.go:35
  in Node.Scan
/usr/local/go/src/database/sql/convert.go:190
  in convertAssign
/usr/local/go/src/database/sql/sql.go:1645
  in Rows.Scan
node_test.go:45
  in TypesSuite.TestQueryNodeWithStringPropertiesOnly
/usr/local/go/src/reflect/value.go:296
  in Value.Call
/usr/local/go/src/runtime/asm_amd64.s:2232
  in goexit
OOPS: 43 passed, 1 PANICKED
--- FAIL: Test (5.27s)
FAIL
exit status 1
FAIL    gopkg.in/cq.v1/types    5.273s
```
