### PR TITLE
Handle nodes with only one property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.3
   
 env:
-  - NEO_VERSION="2.1.3"
+  - NEO_VERSION="2.1.4"
 
 before_script:
   - go get gopkg.in/check.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - 1.3
   
 env:
-  - NEO_VERSION="2.1.4"
+  - NEO_VERSION="2.1.5"
 
 before_script:
   - go get gopkg.in/check.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,10 @@ before_install:
   - neo4j-community-$NEO_VERSION/bin/neo4j start
 
 install:
-  - cd ../../..
-  - mkdir gopkg.in
-  - mv github.com/go-cq/cq gopkg.in/cq.v1
-  - cd gopkg.in/cq.v1
+  - go get gopkg.in/cq.v1
 
 script:
+  - cd ../../gopkg.in/cq.v1/
   - cd types
   - go test -covermode=count -coverprofile=../typescov.out
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - go get gopkg.in/cq.v1
 
 script:
-  - cd ../../gopkg.in/cq.v1/
+  - cd ../../../gopkg.in/cq.v1/
   - cd types
   - go test -covermode=count -coverprofile=../typescov.out
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go: 
-  - 1.3
+  - 1.4
   
 env:
-  - NEO_VERSION="2.1.5"
+  - NEO_VERSION="2.2.1"
 
 before_script:
   - go get gopkg.in/check.v1
@@ -22,6 +22,7 @@ before_install:
   - tar -xzf neo4j-community-$NEO_VERSION-unix.tar.gz
   - echo "org.neo4j.server.transaction.timeout=1" >> neo4j-community-$NEO_VERSION/conf/neo4j-server.properties
   - neo4j-community-$NEO_VERSION/bin/neo4j start
+  - curl -u neo4j:neo4j -H accept:application/json -H content-type:application/json http://localhost:7474/user/neo4j/password -d '{"password":"test"}'
 
 install:
   - go get gopkg.in/cq.v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ after_success:
   - goveralls -coverprofile=bench.out 
   
 before_install:
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - wget dist.neo4j.org/neo4j-community-$NEO_VERSION-unix.tar.gz
   - tar -xzf neo4j-community-$NEO_VERSION-unix.tar.gz
   - echo "org.neo4j.server.transaction.timeout=1" >> neo4j-community-$NEO_VERSION/conf/neo4j-server.properties

--- a/conn_test.go
+++ b/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"flag"
 	"log"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -11,7 +12,7 @@ type ConnSuite struct{}
 
 var (
 	_       = Suite(&ConnSuite{})
-	testURL = flag.String("testdb", "http://localhost:7474/", "the base url for the test db")
+	testURL = flag.String("testdb", "http://neo4j:test@localhost:7474/", "the base url for the test db")
 )
 
 //func Test(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"testing"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -18,7 +19,7 @@ func Test(t *testing.T) {
 }
 
 func testConn() *sql.DB {
-	db, err := sql.Open("neo4j-cypher", "http://localhost:7474/")
+	db, err := sql.Open("neo4j-cypher", *testURL)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,24 @@ func main() {
 	}
 }
 ```
+## Neo4j version support
+
+| **Version** | **Tested** |
+|-------------|------------|
+| 1.9         |     ??     |
+| 2.0         |     ??     |
+| 2.1         |     ??     |
+| 2.2         |     No     |
+
+## Neo4j feature support
+
+| **Feature**          | **Supported?** |
+|----------------------|----------------|
+| Auth                 |  No            |
+| Remote Cypher        |  Yes           |
+| Transactions         |  Yes           |
+| High Availability    |  ??            |
+| Embedded JVM support |  ??            |
 
 ## deployment on Heroku w/ GrapheneDB
 

--- a/readme.md
+++ b/readme.md
@@ -84,15 +84,15 @@ func main() {
 | 1.9         |     No     |
 | 2.0         |     Yes    |
 | 2.1         |     Yes    |
-| 2.2         |     No     |
+| 2.2         |     Yes     |
 
 ## Neo4j feature support
 
 | **Feature**          | **Supported?** |
 |----------------------|----------------|
-| Auth                 |  No            |
+| Auth                 |  Yes           |
 | Remote Cypher        |  Yes           |
-| Transactions         |  Partial (write only)           |
+| Transactions         |  Partial (write only) |
 | High Availability    |  No            |
 | Embedded JVM support |  No            |
 

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ func main() {
 |----------------------|----------------|
 | Auth                 |  No            |
 | Remote Cypher        |  Yes           |
-| Transactions         |  Yes           |
+| Transactions         |  Partial (write only)           |
 | High Availability    |  No            |
 | Embedded JVM support |  No            |
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # cq - cypher queries for database/sql
-A [golang](golang) database/sql implementation for [Cypher](cypher-intro)/[Neo4j](neo4j). I've released v1. I plan to change the API in the near future, but v1 will remain supported for some time.
+A [golang][golang] database/sql implementation for [Cypher][cypher-intro]/[Neo4j][neo4j]. I've released v1. I plan to change the API in the near future, but v1 will remain supported for some time.
 
 If you'd like to use the new [gopkg.in](http://godoc.org/gopkg.in/docs.v1) semantic versioning system:
 

--- a/readme.md
+++ b/readme.md
@@ -81,9 +81,9 @@ func main() {
 
 | **Version** | **Tested** |
 |-------------|------------|
-| 1.9         |     ??     |
-| 2.0         |     ??     |
-| 2.1         |     ??     |
+| 1.9         |     No     |
+| 2.0         |     Yes    |
+| 2.1         |     Yes    |
 | 2.2         |     No     |
 
 ## Neo4j feature support
@@ -93,8 +93,8 @@ func main() {
 | Auth                 |  No            |
 | Remote Cypher        |  Yes           |
 | Transactions         |  Yes           |
-| High Availability    |  ??            |
-| Embedded JVM support |  ??            |
+| High Availability    |  No            |
+| Embedded JVM support |  No            |
 
 ## deployment on Heroku w/ GrapheneDB
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # cq - cypher queries for database/sql
-A database/sql implementation for Cypher. I've released v1. I plan to change the API in the near future, but v1 will remain supported for some time.
+A [golang](golang) database/sql implementation for [Cypher](cypher-intro)/[Neo4j](neo4j). I've released v1. I plan to change the API in the near future, but v1 will remain supported for some time.
 
 If you'd like to use the new [gopkg.in](http://godoc.org/gopkg.in/docs.v1) semantic versioning system:
 
@@ -10,6 +10,7 @@ import "gopkg.in/cq.v1"
 [![Build Status](https://travis-ci.org/go-cq/cq.svg?branch=master)](https://travis-ci.org/go-cq/cq)
 [![Coverage Status](https://img.shields.io/coveralls/go-cq/cq.svg)](https://coveralls.io/r/go-cq/cq?branch=master)
 [![Waffle](https://badge.waffle.io/go-cq/cq.png?label=ready)](https://waffle.io/go-cq/cq)
+[![StackOverflow](https://img.shields.io/badge/StackOverflow-Ask%20a%20question!-blue.svg)](http://stackoverflow.com/questions/ask?tags=go,cq)
 [![Gitter chat](https://badges.gitter.im/go-cq/cq.png)](https://gitter.im/go-cq/cq)
 
 Thanks to [Baron](http://twitter.com/xaprb), [Mike](http://twitter.com/mikearpaia), and [Jason](https://github.com/jmcvetta) for the ideas/motivation to start on this project. Cypher is close enough to SQL that it seems to fit pretty well in the idiomatic database/sql implementation.
@@ -158,3 +159,7 @@ Thanks to issue reporters and [contributors](https://github.com/go-cq/cq/graphs/
 
 MIT license. See license file.
 
+
+[golang]: https://golang.org/
+[neo4j]: http://neo4j.com/
+[cypher-intro]: http://neo4j.com/developer/cypher-query-language/ "Cypher Introduction"

--- a/readme.md
+++ b/readme.md
@@ -7,15 +7,21 @@ If you'd like to use the new [gopkg.in](http://godoc.org/gopkg.in/docs.v1) seman
 import "gopkg.in/cq.v1"
 ```
 
+### status
+
 [![Build Status](https://travis-ci.org/go-cq/cq.svg?branch=master)](https://travis-ci.org/go-cq/cq)
 [![Coverage Status](https://img.shields.io/coveralls/go-cq/cq.svg)](https://coveralls.io/r/go-cq/cq?branch=master)
 [![Waffle](https://badge.waffle.io/go-cq/cq.png?label=ready)](https://waffle.io/go-cq/cq)
+
+### getting help
 [![StackOverflow](https://img.shields.io/badge/StackOverflow-Ask%20a%20question!-blue.svg)](http://stackoverflow.com/questions/ask?tags=go,cq)
 [![Gitter chat](https://badges.gitter.im/go-cq/cq.png)](https://gitter.im/go-cq/cq)
 
+### thanks
+
 Thanks to [Baron](http://twitter.com/xaprb), [Mike](http://twitter.com/mikearpaia), and [Jason](https://github.com/jmcvetta) for the ideas/motivation to start on this project. Cypher is close enough to SQL that it seems to fit pretty well in the idiomatic database/sql implementation.
 
-#### Other Go drivers for Neo4j that support Cypher
+### Other Go drivers for Neo4j that support Cypher
 * [Neoism](https://github.com/jmcvetta/neoism) (a careful/complete REST API implementation)
 * [GonormCypher](https://github.com/marpaia/GonormCypher) (a port of AnormCypher, to get up and running quickly)
 * [neo4j-go](https://github.com/jakewins/neo4j-go) (Jake's experimental Cypher driver)

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ import "gopkg.in/cq.v1"
 
 ### status
 
-[![Build Status](https://travis-ci.org/go-cq/cq.svg?branch=master)](https://travis-ci.org/go-cq/cq)
+[![Build Status](https://travis-ci.org/go-cq/cq.svg?branch=v1)](https://travis-ci.org/go-cq/cq)
 [![Coverage Status](https://img.shields.io/coveralls/go-cq/cq.svg)](https://coveralls.io/r/go-cq/cq?branch=master)
 [![Waffle](https://badge.waffle.io/go-cq/cq.png?label=ready)](https://waffle.io/go-cq/cq)
 

--- a/types/cyphervalue_test.go
+++ b/types/cyphervalue_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log"
 	"testing"
+
 	. "gopkg.in/check.v1"
 	_ "gopkg.in/cq.v1"
 	"gopkg.in/cq.v1/types"
@@ -18,7 +19,7 @@ func Test(t *testing.T) {
 }
 
 func testConn() *sql.DB {
-	db, err := sql.Open("neo4j-cypher", "http://localhost:7474/")
+	db, err := sql.Open("neo4j-cypher", "http://neo4j:test@localhost:7474/")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/types/node.go
+++ b/types/node.go
@@ -32,7 +32,20 @@ func (n *Node) Scan(value interface{}) error {
 		if ok != true {
 			break
 		}
-		n.Properties = inner.Val.(map[string]CypherValue)
+		switch inner.Val.(type) {
+		case map[string]string:
+			ss := inner.Val.(map[string]string)
+			sc := make(map[string]CypherValue, len(ss))
+			for k, v := range ss {
+				sc[k] = CypherValue{
+					Type: CypherString,
+					Val: v,
+				}
+			}
+			n.Properties = sc
+		case map[string]CypherValue:
+			n.Properties = inner.Val.(map[string]CypherValue)
+		}
 		inner, ok = cv["self"]
 		if ok != true {
 			break

--- a/types/node.go
+++ b/types/node.go
@@ -62,7 +62,17 @@ func (n *Node) Labels(baseURL string) ([]string, error) {
 	}
 	labelURL.Scheme = base.Scheme
 	labelURL.User = base.User
-	resp, err := http.Get(n.LabelURI)
+	req, err := http.NewRequest("GET", n.LabelURI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(labelURL.User)
+	pass, _ := labelURL.User.Password()
+	user := labelURL.User.Username()
+	req.SetBasicAuth(user, pass)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/types/node_test.go
+++ b/types/node_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *TypesSuite) TestQueryNode(c *C) {
-	conn, err := sql.Open("neo4j-cypher", "http://localhost:7474/")
+	conn, err := sql.Open("neo4j-cypher", "http://neo4j:test@localhost:7474/")
 	c.Assert(err, IsNil)
 	stmt, err := conn.Prepare(`create (a:Test {foo:"bar", i:1}) return a`)
 	c.Assert(err, IsNil)

--- a/types/node_test.go
+++ b/types/node_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func (s *TypesSuite) TestQueryNode(c *C) {
-	conn, err := sql.Open("neo4j-cypher", "http://neo4j:test@localhost:7474/")
+	testURL := "http://neo4j:test@localhost:7474/"
+	conn, err := sql.Open("neo4j-cypher", testURL)
 	c.Assert(err, IsNil)
 	stmt, err := conn.Prepare(`create (a:Test {foo:"bar", i:1}) return a`)
 	c.Assert(err, IsNil)
@@ -25,7 +26,7 @@ func (s *TypesSuite) TestQueryNode(c *C) {
 	t1.Properties["foo"] = types.CypherValue{types.CypherString, "bar"}
 	t1.Properties["i"] = types.CypherValue{types.CypherInt, 1}
 	c.Assert(test.Properties, DeepEquals, t1.Properties)
-	labels, err := test.Labels("http://localhost:7474/")
+	labels, err := test.Labels(testURL)
 	c.Assert(err, IsNil)
 	c.Assert(labels, DeepEquals, []string{"Test"})
 }

--- a/types/node_test.go
+++ b/types/node_test.go
@@ -30,3 +30,25 @@ func (s *TypesSuite) TestQueryNode(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(labels, DeepEquals, []string{"Test"})
 }
+
+func (s *TypesSuite) TestQueryNodeWithOneProperty(c *C) {
+	testURL := "http://neo4j:test@localhost:7474/"
+	conn, err := sql.Open("neo4j-cypher", testURL)
+	c.Assert(err, IsNil)
+	stmt, err := conn.Prepare(`create (a:Test {i:1}) return a`)
+	c.Assert(err, IsNil)
+	rows, err := stmt.Query()
+	c.Assert(err, IsNil)
+
+	rows.Next()
+	var test types.Node
+	err = rows.Scan(&test)
+	c.Assert(err, IsNil)
+	t1 := types.Node{}
+	t1.Properties = map[string]types.CypherValue{}
+	t1.Properties["i"] = types.CypherValue{types.CypherInt, 1}
+	c.Assert(test.Properties, DeepEquals, t1.Properties)
+	labels, err := test.Labels(testURL)
+	c.Assert(err, IsNil)
+	c.Assert(labels, DeepEquals, []string{"Test"})
+}


### PR DESCRIPTION
I ran into a problem when trying to query a node with only one property.  Looks like a node with one property is interpreted as a `map[string]string` and is trying to cast to a `map[string]CypherValue` when scanning the row.

I'm not sure if what I've done is the best way of solving this problem; I've created a test case for it and none of the other tests broke. 

Hope this is helpful
