### PR TITLE
Properly handle escaped chars

### DIFF
--- a/tags
+++ b/tags
@@ -1,0 +1,6 @@
+!_TAG_FILE_FORMAT	2
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
+!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
+!_TAG_PROGRAM_NAME	gotags
+!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
+!_TAG_PROGRAM_VERSION	1.3.0

--- a/tags
+++ b/tags
@@ -1,6 +1,0 @@
-!_TAG_FILE_FORMAT	2
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
-!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
-!_TAG_PROGRAM_NAME	gotags
-!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
-!_TAG_PROGRAM_VERSION	1.3.0

--- a/types/cyphervalue.go
+++ b/types/cyphervalue.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 )
 
 type CypherType uint8
@@ -219,7 +218,10 @@ func (c *CypherValue) UnmarshalJSON(b []byte) error {
 	if len(b) > 0 {
 		switch b[0] {
 		case byte('"'):
-			c.Val = strings.Trim(str, "\"")
+			c.Val, err = strconv.Unquote(str)
+			if err != nil {
+				return err
+			}
 			c.Type = CypherString
 			return nil
 		case byte('{'):

--- a/types/cyphervalue_test.go
+++ b/types/cyphervalue_test.go
@@ -74,6 +74,16 @@ func (s *TypesSuite) TestQueryCypherValueString(c *C) {
 	c.Assert(test.Val, Equals, "asdf")
 }
 
+func (s *TypesSuite) TestQueryCypherValueStringEscapeChars(c *C) {
+	rows := prepareAndQuery(`return '\\\"\''`)
+	rows.Next()
+	var test types.CypherValue
+	err := rows.Scan(&test)
+	c.Assert(err, IsNil)
+	c.Assert(test.Type, Equals, types.CypherString)
+	c.Assert(test.Val, Equals, `\"'`)
+}
+
 func (s *TypesSuite) TestQueryCypherValueInt64(c *C) {
 	rows := prepareAndQuery("return 9223372000000000000")
 	rows.Next()

--- a/types/cyphervalue_test.go
+++ b/types/cyphervalue_test.go
@@ -75,13 +75,13 @@ func (s *TypesSuite) TestQueryCypherValueString(c *C) {
 }
 
 func (s *TypesSuite) TestQueryCypherValueStringEscapeChars(c *C) {
-	rows := prepareAndQuery(`return '\\\"\''`)
+	rows := prepareAndQuery(`return '\\\"\'\r\n\t\f\b\u672C'`)
 	rows.Next()
 	var test types.CypherValue
 	err := rows.Scan(&test)
 	c.Assert(err, IsNil)
 	c.Assert(test.Type, Equals, types.CypherString)
-	c.Assert(test.Val, Equals, `\"'`)
+	c.Assert(test.Val, Equals, "\\\"'\r\n\t\f\b\u672C")
 }
 
 func (s *TypesSuite) TestQueryCypherValueInt64(c *C) {


### PR DESCRIPTION
@wfreeman 

I'm using this library for a Neo project I have.  I found this issue with escaped characters in string literals.  Pretty simple fix. I'd appreciate it if we could get this into v1 as soon as we can, as it's causing some issues for my project.

Thanks!
