### PR TITLE
Expose http.RoundTripper

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -24,10 +24,6 @@ func init() {
 
 var (
 	cqVersion = "1.0.4"
-	tr        = &http.Transport{
-		DisableKeepAlives: true,
-	}
-	client = &http.Client{}
 )
 
 type conn struct {
@@ -100,7 +96,7 @@ func Open(baseURL string) (driver.Conn, error) {
 }
 
 func getNeoBase(url string) (*neo4jBase, error) {
-	res, err := http.Get(url)
+	res, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +112,7 @@ func getNeoBase(url string) (*neo4jBase, error) {
 }
 
 func getNeoData(url string) (*neo4jData, error) {
-	res, err := http.Get(url)
+	res, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/transport.go
+++ b/transport.go
@@ -1,7 +1,7 @@
 package cq
 
 import (
-	"github.com/origininvesting/cq/types"
+	"gopkg.in/cq.v1/types"
 	"net/http"
 )
 

--- a/transport.go
+++ b/transport.go
@@ -1,19 +1,19 @@
 package cq
 
 import (
-  "net/http"
-  "github.com/origininvesting/cq/types"
+	"github.com/origininvesting/cq/types"
+	"net/http"
 )
 
 var (
-  transport http.RoundTripper = &http.Transport{}
-  client = &http.Client{
-    Transport: transport,
-  }
+	transport http.RoundTripper = &http.Transport{}
+	client                      = &http.Client{
+		Transport: transport,
+	}
 )
 
 func SetTransport(rt http.RoundTripper) {
 	transport = rt
 	client.Transport = transport
-  types.SetTransport(rt)
+	types.SetTransport(rt)
 }

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,19 @@
+package cq
+
+import (
+  "net/http"
+  "github.com/origininvesting/cq/types"
+)
+
+var (
+  transport http.RoundTripper = &http.Transport{}
+  client = &http.Client{
+    Transport: transport,
+  }
+)
+
+func SetTransport(rt http.RoundTripper) {
+	transport = rt
+	client.Transport = transport
+  types.SetTransport(rt)
+}

--- a/types/node.go
+++ b/types/node.go
@@ -83,7 +83,6 @@ func (n *Node) Labels(baseURL string) ([]string, error) {
 	pass, _ := labelURL.User.Password()
 	user := labelURL.User.Username()
 	req.SetBasicAuth(user, pass)
-	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/types/transport.go
+++ b/types/transport.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+  "net/http"
+)
+
+var (
+  transport http.RoundTripper = &http.Transport{}
+  client = &http.Client{
+    Transport: transport,
+  }
+)
+
+func SetTransport(rt http.RoundTripper) {
+	transport = rt
+	client.Transport = transport
+}

--- a/types/transport.go
+++ b/types/transport.go
@@ -1,14 +1,14 @@
 package types
 
 import (
-  "net/http"
+	"net/http"
 )
 
 var (
-  transport http.RoundTripper = &http.Transport{}
-  client = &http.Client{
-    Transport: transport,
-  }
+	transport http.RoundTripper = &http.Transport{}
+	client                      = &http.Client{
+		Transport: transport,
+	}
 )
 
 func SetTransport(rt http.RoundTripper) {


### PR DESCRIPTION
I wanted to use `go-cq` on Google App Engine but it's not possible since I can't set the `http.RoundTripper` instance. So I came up with that solution.
