### PR TITLE
Fix a bug that prevented the creation of a transaction in Begin()

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -51,7 +51,8 @@ func (c *conn) Begin() (driver.Tx, error) {
 	if c.transactionURL == "" {
 		return nil, ErrTransactionsNotSupported
 	}
-	transResponse, err := getTransactionResponse(c.transactionURL, cypherTransaction{})
+	transResponse, err := getTransactionResponse(c.transactionURL,
+		cypherTransaction{Statements: make([]cypherTransactionStatement, 0)})
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func (tx *cypherTransaction) exec() error {
 
 func (tx *cypherTransaction) Commit() error {
 	if tx.Statements == nil {
-		return nil	
+		return nil
 	}
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(tx)


### PR DESCRIPTION
update call in getTransactionResponse to take a cypherTransaction with statements being a slice of length 0 rather than a nil slice

The POST request to http://localhost:7474/db/data/transaction/ with an empty cypherTransaction resulted in a request body of {"statements":nil}
Given cypherTransaction with an slice of length 0 results in the struct being decoded into a request body of {"statements":[]} 
Doing so will prevent neo4j from throwing the time parse error